### PR TITLE
Support Mobile event

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -18,7 +18,7 @@ org.gradle.jvmargs=-Xmx1536m
 
 libRepositoryName=Mozilla-Mobile
 libGroupId=org.mozilla.telemetry
-libVersion=1.1.1
+libVersion=1.2.0
 libUrl=https://github.com/mozilla-mobile/telemetry-android
 libVcsUrl=https://github.com/mozilla-mobile/telemetry-android.git
 

--- a/telemetry/src/main/java/org/mozilla/telemetry/ping/TelemetryEventPingBuilder.java
+++ b/telemetry/src/main/java/org/mozilla/telemetry/ping/TelemetryEventPingBuilder.java
@@ -15,7 +15,7 @@ import org.mozilla.telemetry.measurement.SettingsMeasurement;
 import org.mozilla.telemetry.measurement.TimezoneOffsetMeasurement;
 
 public class TelemetryEventPingBuilder extends TelemetryPingBuilder {
-    public static final String TYPE = "focus-event";
+    public static final String TYPE = "mobile-event";
     private static final int VERSION = 1;
 
     private EventsMeasurement eventsMeasurement;

--- a/telemetry/src/main/java/org/mozilla/telemetry/ping/TelemetryEventPingBuilder.java
+++ b/telemetry/src/main/java/org/mozilla/telemetry/ping/TelemetryEventPingBuilder.java
@@ -5,7 +5,9 @@
 package org.mozilla.telemetry.ping;
 
 import org.mozilla.telemetry.config.TelemetryConfiguration;
+import org.mozilla.telemetry.measurement.ArchMeasurement;
 import org.mozilla.telemetry.measurement.CreatedTimestampMeasurement;
+import org.mozilla.telemetry.measurement.DeviceMeasurement;
 import org.mozilla.telemetry.measurement.EventsMeasurement;
 import org.mozilla.telemetry.measurement.LocaleMeasurement;
 import org.mozilla.telemetry.measurement.OperatingSystemMeasurement;
@@ -30,6 +32,8 @@ public class TelemetryEventPingBuilder extends TelemetryPingBuilder {
         addMeasurement(new CreatedTimestampMeasurement());
         addMeasurement(new TimezoneOffsetMeasurement());
         addMeasurement(new SettingsMeasurement(configuration));
+        addMeasurement(new ArchMeasurement());
+        addMeasurement(new DeviceMeasurement());
         addMeasurement(eventsMeasurement = new EventsMeasurement(configuration));
     }
 

--- a/telemetry/src/test/java/org/mozilla/telemetry/TelemetryTest.java
+++ b/telemetry/src/test/java/org/mozilla/telemetry/TelemetryTest.java
@@ -187,7 +187,7 @@ public class TelemetryTest {
         assertEquals(0, storage.countStoredPings(TelemetryEventPingBuilder.TYPE));
 
         final RecordedRequest request = server.takeRequest();
-        assertEquals("POST /submit/telemetry/ffffffff-0000-0000-ffff-ffffffffffff/focus-event/TelemetryTest/12.1.1/test/456?v=4 HTTP/1.1", request.getRequestLine());
+        assertEquals("POST /submit/telemetry/ffffffff-0000-0000-ffff-ffffffffffff/mobile-event/TelemetryTest/12.1.1/test/456?v=4 HTTP/1.1", request.getRequestLine());
         assertEquals("application/json; charset=utf-8", request.getHeader("Content-Type"));
         assertEquals(TEST_USER_AGENT, request.getHeader("User-Agent"));
         assertNotNull(request.getHeader("Date"));

--- a/telemetry/src/test/java/org/mozilla/telemetry/ping/TelemetryEventPingBuilderTest.java
+++ b/telemetry/src/test/java/org/mozilla/telemetry/ping/TelemetryEventPingBuilderTest.java
@@ -10,6 +10,7 @@ import org.mozilla.telemetry.config.TelemetryConfiguration;
 import org.robolectric.RobolectricTestRunner;
 import org.robolectric.RuntimeEnvironment;
 
+import java.util.Arrays;
 import java.util.Map;
 import java.util.UUID;
 
@@ -27,7 +28,7 @@ public class TelemetryEventPingBuilderTest {
         final TelemetryPing ping = builder.build();
 
         assertUUID(ping.getDocumentId());
-        assertEquals("focus-event", ping.getType());
+        assertEquals("mobile-event", ping.getType());
 
         final Map<String, Object> results = ping.getMeasurementResults();
         assertNotNull(results);
@@ -43,6 +44,12 @@ public class TelemetryEventPingBuilderTest {
 
         assertTrue(results.containsKey("osversion"));
         assertEquals("16", results.get("osversion"));
+
+        assertTrue(results.containsKey("arch"));
+        assertEquals("unknown", results.get("arch"));
+
+        assertTrue(results.containsKey("device"));
+        assertEquals("unknown-unknown", results.get("device"));
     }
 
     @Test


### PR DESCRIPTION
To fix #59 

I'm uncertain if we should merge this into master since we might still keep focus-event for a while. Personally I'd think that merging this into a separate branch will be more feasible atm, @pocmo what do you think?

Summary:
1. Switch from focus-event to mobile-event 
2. Use existing ArchMeasurement and DeviceMeasurement and add them to event ping
-> Note that the tests are currently using the default "unknown" and "unkonwn-unknown" instead of spying.
3. Bump version to 1.2.0