### PR TITLE
Add mobile-event; add processStartTimestamp

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -18,7 +18,7 @@ org.gradle.jvmargs=-Xmx1536m
 
 libRepositoryName=Mozilla-Mobile
 libGroupId=org.mozilla.telemetry
-libVersion=1.1.1
+libVersion=1.2.0
 libUrl=https://github.com/mozilla-mobile/telemetry-android
 libVcsUrl=https://github.com/mozilla-mobile/telemetry-android.git
 

--- a/telemetry/src/main/java/org/mozilla/telemetry/Telemetry.java
+++ b/telemetry/src/main/java/org/mozilla/telemetry/Telemetry.java
@@ -15,6 +15,7 @@ import org.mozilla.telemetry.measurement.EventsMeasurement;
 import org.mozilla.telemetry.net.TelemetryClient;
 import org.mozilla.telemetry.ping.TelemetryCorePingBuilder;
 import org.mozilla.telemetry.ping.TelemetryEventPingBuilder;
+import org.mozilla.telemetry.ping.TelemetryMobileEventPingBuilder;
 import org.mozilla.telemetry.ping.TelemetryPing;
 import org.mozilla.telemetry.ping.TelemetryPingBuilder;
 import org.mozilla.telemetry.schedule.TelemetryScheduler;
@@ -83,13 +84,27 @@ public class Telemetry {
         executor.submit(new Runnable() {
             @Override
             public void run() {
-                EventsMeasurement measurement = ((TelemetryEventPingBuilder) pingBuilders.get(TelemetryEventPingBuilder.TYPE))
-                        .getEventsMeasurement();
+                // We migrated from focus-event to mobile-event and unfortunately, this code was hard-coded to expect
+                // a focus-event ping builder. We work around this by checking our new hardcoded code first for the new
+                // ping type and then falling back on the legacy ping type.
+                final TelemetryPingBuilder mobileEventBuilder = pingBuilders.get(TelemetryMobileEventPingBuilder.TYPE);
+                final TelemetryPingBuilder focusEventBuilder = pingBuilders.get(TelemetryEventPingBuilder.TYPE);
+                final EventsMeasurement measurement;
+                final String addedPingType;
+                if (mobileEventBuilder != null) {
+                    measurement = ((TelemetryMobileEventPingBuilder) mobileEventBuilder).getEventsMeasurement();
+                    addedPingType = mobileEventBuilder.getType();
+                } else if (focusEventBuilder != null) {
+                    measurement = ((TelemetryEventPingBuilder) focusEventBuilder).getEventsMeasurement();
+                    addedPingType = focusEventBuilder.getType();
+                } else {
+                    throw new IllegalStateException("Expect either TelemetryEventPingBuilder or " +
+                            "TelemetryMobileEventPingBuilder to be added to queue events");
+                }
 
                 measurement.add(event);
-
                 if (measurement.getEventCount() >= configuration.getMaximumNumberOfEventsPerPing()) {
-                    queuePing(TelemetryEventPingBuilder.TYPE);
+                    queuePing(addedPingType);
                 }
             }
         });

--- a/telemetry/src/main/java/org/mozilla/telemetry/config/TelemetryConfiguration.java
+++ b/telemetry/src/main/java/org/mozilla/telemetry/config/TelemetryConfiguration.java
@@ -37,6 +37,8 @@ public class TelemetryConfiguration {
     private static final int DEFAULT_MAXIMUM_PINGS_PER_TYPE = 40;
     private static final int DEFAULT_MAXIMUM_PING_UPLOADS_PER_DAY = 100;
 
+    private static final long classLoadTimestampMillis = System.currentTimeMillis();
+
     private final Context context;
 
     private String appName;
@@ -410,5 +412,9 @@ public class TelemetryConfiguration {
     public TelemetryConfiguration setSettingsProvider(SettingsMeasurement.SettingsProvider settingsProvider) {
         this.settingsProvider = settingsProvider;
         return this;
+    }
+
+    public long getClassLoadTimestampMillis() {
+        return classLoadTimestampMillis;
     }
 }

--- a/telemetry/src/main/java/org/mozilla/telemetry/measurement/ProcessStartTimestampMeasurement.java
+++ b/telemetry/src/main/java/org/mozilla/telemetry/measurement/ProcessStartTimestampMeasurement.java
@@ -1,0 +1,23 @@
+package org.mozilla.telemetry.measurement;
+
+import org.mozilla.telemetry.Telemetry;
+import org.mozilla.telemetry.config.TelemetryConfiguration;
+
+public class ProcessStartTimestampMeasurement extends TelemetryMeasurement {
+    private static final String FIELD_NAME = "processStartTimestamp";
+
+    private final long processLoadTimestampMillis;
+
+    public ProcessStartTimestampMeasurement(final TelemetryConfiguration configuration) {
+        super(FIELD_NAME);
+
+        // Ideally, we'd get the process start time, but considering Telemetry is
+        // expected to be loaded early in the Activity lifecycle, this is good enough.
+        processLoadTimestampMillis = configuration.getClassLoadTimestampMillis();
+    }
+
+    @Override
+    public Object flush() {
+        return processLoadTimestampMillis;
+    }
+}

--- a/telemetry/src/main/java/org/mozilla/telemetry/ping/TelemetryMobileEventPingBuilder.java
+++ b/telemetry/src/main/java/org/mozilla/telemetry/ping/TelemetryMobileEventPingBuilder.java
@@ -10,6 +10,7 @@ import org.mozilla.telemetry.measurement.EventsMeasurement;
 import org.mozilla.telemetry.measurement.LocaleMeasurement;
 import org.mozilla.telemetry.measurement.OperatingSystemMeasurement;
 import org.mozilla.telemetry.measurement.OperatingSystemVersionMeasurement;
+import org.mozilla.telemetry.measurement.ProcessStartTimestampMeasurement;
 import org.mozilla.telemetry.measurement.SequenceMeasurement;
 import org.mozilla.telemetry.measurement.SettingsMeasurement;
 import org.mozilla.telemetry.measurement.TimezoneOffsetMeasurement;
@@ -29,6 +30,7 @@ public class TelemetryMobileEventPingBuilder extends TelemetryPingBuilder {
     public TelemetryMobileEventPingBuilder(TelemetryConfiguration configuration) {
         super(configuration, TYPE, VERSION);
 
+        addMeasurement(new ProcessStartTimestampMeasurement(configuration));
         addMeasurement(new SequenceMeasurement(configuration, this));
         addMeasurement(new LocaleMeasurement());
         addMeasurement(new OperatingSystemMeasurement());

--- a/telemetry/src/main/java/org/mozilla/telemetry/ping/TelemetryMobileEventPingBuilder.java
+++ b/telemetry/src/main/java/org/mozilla/telemetry/ping/TelemetryMobileEventPingBuilder.java
@@ -15,20 +15,18 @@ import org.mozilla.telemetry.measurement.SettingsMeasurement;
 import org.mozilla.telemetry.measurement.TimezoneOffsetMeasurement;
 
 /**
- * A telemetry ping builder for pings of type "focus-event".
+ * A telemetry ping builder for events of type "mobile-event".
  *
- * @deprecated prefer {@link TelemetryMobileEventPingBuilder}. "focus-event" was the original type but
- * we're migrating to the generic "mobile-event" type. In order to prevent breaking public APIs, we couldn't
- * change this class directly and copied it into the new ping type.
+ * See the schema for more details:
+ *   https://github.com/mozilla-services/mozilla-pipeline-schemas/blob/master/schemas/telemetry/mobile-event/mobile-event.1.schema.json
  */
-@Deprecated
-public class TelemetryEventPingBuilder extends TelemetryPingBuilder {
-    public static final String TYPE = "focus-event";
+public class TelemetryMobileEventPingBuilder extends TelemetryPingBuilder {
+    public static final String TYPE = "mobile-event";
     private static final int VERSION = 1;
 
     private EventsMeasurement eventsMeasurement;
 
-    public TelemetryEventPingBuilder(TelemetryConfiguration configuration) {
+    public TelemetryMobileEventPingBuilder(TelemetryConfiguration configuration) {
         super(configuration, TYPE, VERSION);
 
         addMeasurement(new SequenceMeasurement(configuration, this));

--- a/telemetry/src/test/java/org/mozilla/telemetry/measurement/ProcessStartTimestampMeasurementTest.java
+++ b/telemetry/src/test/java/org/mozilla/telemetry/measurement/ProcessStartTimestampMeasurementTest.java
@@ -1,0 +1,21 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.telemetry.measurement;
+
+import org.junit.Test;
+import org.mozilla.telemetry.config.TelemetryConfiguration;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+public class ProcessStartTimestampMeasurementTest {
+    @Test
+    public void testTimestampComesFromTelemetryConfiguration() throws Exception {
+        final long expectedTimestamp = 1357389201;
+        final TelemetryConfiguration mockTelemetryConfiguration = mock(TelemetryConfiguration.class);
+        when(mockTelemetryConfiguration.getClassLoadTimestampMillis()).thenReturn(expectedTimestamp);
+        assertEquals(expectedTimestamp, new ProcessStartTimestampMeasurement(mockTelemetryConfiguration).flush());
+    }
+}

--- a/telemetry/src/test/java/org/mozilla/telemetry/ping/TelemetryMobileEventPingBuilderTest.java
+++ b/telemetry/src/test/java/org/mozilla/telemetry/ping/TelemetryMobileEventPingBuilderTest.java
@@ -1,0 +1,78 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.telemetry.ping;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mozilla.telemetry.config.TelemetryConfiguration;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.RuntimeEnvironment;
+
+import java.util.Map;
+import java.util.UUID;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+@RunWith(RobolectricTestRunner.class)
+public class TelemetryMobileEventPingBuilderTest {
+    @Test
+    public void testBuildingEmptyPing() {
+        final TelemetryConfiguration configuration = new TelemetryConfiguration(RuntimeEnvironment.application);
+        final TelemetryMobileEventPingBuilder builder = new TelemetryMobileEventPingBuilder(configuration);
+
+        final TelemetryPing ping = builder.build();
+
+        assertUUID(ping.getDocumentId());
+        assertEquals("mobile-event", ping.getType());
+
+        final Map<String, Object> results = ping.getMeasurementResults();
+        assertNotNull(results);
+
+        assertTrue(results.containsKey("seq"));
+        assertEquals(1L, results.get("seq"));
+
+        assertTrue(results.containsKey("locale"));
+        assertEquals("en-US", results.get("locale"));
+
+        assertTrue(results.containsKey("os"));
+        assertEquals("Android", results.get("os"));
+
+        assertTrue(results.containsKey("osversion"));
+        assertEquals("16", results.get("osversion"));
+    }
+
+    @Test
+    public void testSequenceNumber() {
+        final TelemetryConfiguration configuration = new TelemetryConfiguration(RuntimeEnvironment.application);
+        final TelemetryMobileEventPingBuilder builder = new TelemetryMobileEventPingBuilder(configuration);
+
+        {
+            final TelemetryPing ping1 = builder.build();
+
+            final Map<String, Object> results = ping1.getMeasurementResults();
+            assertNotNull(results);
+
+            assertTrue(results.containsKey("seq"));
+            assertEquals(1L, results.get("seq"));
+        }
+
+        {
+            final TelemetryPing ping2 = builder.build();
+
+            final Map<String, Object> results2 = ping2.getMeasurementResults();
+            assertNotNull(results2);
+
+            assertTrue(results2.containsKey("seq"));
+            assertEquals(2L, results2.get("seq"));
+        }
+    }
+
+    private void assertUUID(String uuid) {
+        //noinspection ResultOfMethodCallIgnored
+        UUID.fromString(uuid); // Should throw IllegalArgumentException if parameter does not conform
+    }
+}

--- a/telemetry/src/test/java/org/mozilla/telemetry/serialize/JSONPingSerializerTest.java
+++ b/telemetry/src/test/java/org/mozilla/telemetry/serialize/JSONPingSerializerTest.java
@@ -6,6 +6,7 @@ package org.mozilla.telemetry.serialize;
 
 import org.json.JSONArray;
 import org.json.JSONObject;
+import org.junit.FixMethodOrder;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mozilla.telemetry.config.TelemetryConfiguration;
@@ -13,6 +14,7 @@ import org.mozilla.telemetry.event.TelemetryEvent;
 import org.mozilla.telemetry.measurement.EventsMeasurement;
 import org.mozilla.telemetry.ping.TelemetryCorePingBuilder;
 import org.mozilla.telemetry.ping.TelemetryEventPingBuilder;
+import org.mozilla.telemetry.ping.TelemetryMobileEventPingBuilder;
 import org.mozilla.telemetry.ping.TelemetryPing;
 import org.robolectric.RobolectricTestRunner;
 import org.robolectric.RuntimeEnvironment;
@@ -27,6 +29,46 @@ import static org.junit.Assert.assertTrue;
 public class JSONPingSerializerTest {
     @Test
     public void testSerializingEventPing() throws Exception {
+        final TelemetryConfiguration configuration = new TelemetryConfiguration(RuntimeEnvironment.application);
+        final TelemetryMobileEventPingBuilder builder = new TelemetryMobileEventPingBuilder(configuration);
+        final TelemetryPing ping = builder.build();
+
+        final TelemetryPingSerializer serializer = new JSONPingSerializer();
+
+        final String serializedPing = serializer.serialize(ping);
+
+        // This will throw if the serializer doesn't produce valid JSON.
+        final JSONObject json = new JSONObject(serializedPing);
+
+        assertTrue(json.has("clientId"));
+        assertTrue(json.has("os"));
+        assertTrue(json.has("osversion"));
+        assertTrue(json.has("v"));
+        assertTrue(json.has("tz"));
+        assertTrue(json.has("os"));
+        assertTrue(json.has("locale"));
+        assertTrue(json.has("seq"));
+        assertTrue(json.has("events"));
+        assertTrue(json.has("settings"));
+
+        assertEquals(1, json.getLong("seq"));
+
+        final JSONArray events = json.getJSONArray("events");
+        assertNotNull(events);
+        assertEquals(0, events.length());
+
+        final JSONObject settings = json.getJSONObject("settings");
+        assertNotNull(settings);
+        assertEquals(0, settings.length());
+
+        final UUID clientId = UUID.fromString(json.getString("clientId"));
+        assertNotNull(clientId);
+        assertEquals(4, clientId.version());
+    }
+
+    @Test
+    @Deprecated // If you change this test, change the one above it.
+    public void testSerializingEventPingLegacyPingType() throws Exception {
         final TelemetryConfiguration configuration = new TelemetryConfiguration(RuntimeEnvironment.application);
         final TelemetryEventPingBuilder builder = new TelemetryEventPingBuilder(configuration);
         final TelemetryPing ping = builder.build();
@@ -66,6 +108,44 @@ public class JSONPingSerializerTest {
 
     @Test
     public void testSerializingEventPingWithEvents() throws Exception {
+        final TelemetryConfiguration configuration = new TelemetryConfiguration(RuntimeEnvironment.application);
+        final TelemetryMobileEventPingBuilder builder = new TelemetryMobileEventPingBuilder(configuration);
+
+        final EventsMeasurement measurement = builder.getEventsMeasurement();
+        measurement.add(TelemetryEvent.create("action", "open", "app"));
+        measurement.add(TelemetryEvent.create("action", "type_url", "search_bar"));
+        measurement.add(TelemetryEvent.create("action", "click", "erase_button"));
+
+        final TelemetryPing ping = builder.build();
+        final TelemetryPingSerializer serializer = new JSONPingSerializer();
+
+        final String serializedPing = serializer.serialize(ping);
+
+        final JSONObject json = new JSONObject(serializedPing);
+        assertTrue(json.has("events"));
+
+        final JSONArray events = json.getJSONArray("events");
+        assertEquals(3, events.length());
+
+        final JSONArray event1 = events.getJSONArray(0);
+        assertEquals("action", event1.getString(1));
+        assertEquals("open", event1.getString(2));
+        assertEquals("app", event1.getString(3));
+
+        final JSONArray event2 = events.getJSONArray(1);
+        assertEquals("action", event2.getString(1));
+        assertEquals("type_url", event2.getString(2));
+        assertEquals("search_bar", event2.getString(3));
+
+        final JSONArray event3 = events.getJSONArray(2);
+        assertEquals("action", event3.getString(1));
+        assertEquals("click", event3.getString(2));
+        assertEquals("erase_button", event3.getString(3));
+    }
+
+    @Test
+    @Deprecated // If you change this test, change the one above it.
+    public void testSerializingEventPingWithEventsLegacyPingType() throws Exception {
         final TelemetryConfiguration configuration = new TelemetryConfiguration(RuntimeEnvironment.application);
         final TelemetryEventPingBuilder builder = new TelemetryEventPingBuilder(configuration);
 


### PR DESCRIPTION
#59, #63 

One concern I have is that Frank's description of the new timestamp doesn't make much sense to me: "it allows us to have an absolute timestamp for all events, rather than just a relative one"

But The EventPingBuilder appears to add the current time on device when the ping is created (`created`). How does `processStartTimestamp` interact with this one? i.e. `created` seems like an absolute timestamp and we don’t have a relative timestamp (i.e. one using the system uptime, rather than the current time)